### PR TITLE
Fix Currently Unusable Mod

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -34,6 +34,8 @@ local craft_table_form =
 	"list[current_player;craft;1.75,0.5;3,3;]"..
 	"image[4.85,1.45;1,1;gui_furnace_arrow_bg.png^[transformR270]"..
 	"list[current_player;craftpreview;5.75,1.5;1,1;]"..
+	"listring[current_player;main]"..
+	"listring[current_player;craft]"..
 	default.get_hotbar_bg(0,4.25)
 
 -- On_rightclick callback for craft tables

--- a/api.lua
+++ b/api.lua
@@ -54,11 +54,13 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		local meta = player:get_meta()
 		drop_craft(player, minetest.deserialize(meta:get_string("craft_table:craft_table_pos")))
 		meta:set_string("craft_table:craft_table_pos", "")
+		meta:set_string("craft_table:craft_table_grid", "2x2")
 	end
 end)
 
 -- Check craft table
 local check_craft_table = function(player)
+
 	local meta = player:get_meta()
 	if meta:get_string("craft_table:craft_table_pos") == ""
 		or meta:get_string("craft_table:craft_table_node") == ""

--- a/api.lua
+++ b/api.lua
@@ -3,7 +3,7 @@
 	Copyright (C) 2020 BrunoMine (https://github.com/BrunoMine)
 	
 	You should have received a copy of the GNU General Public License
-	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	along with this program. If not, see <https://www.gnu.org/licenses/>.
 	
 	API
   ]]
@@ -17,7 +17,7 @@ local function drop_craft(player, pos)
 	for i = 1, size do
 		local item = invref:get_stack("craft", i)
 		if item ~= nil then
-			minetest.env:add_item({x = pos.x + (((math.random(1, 70)/100)-0.35)), y = pos.y+1, z = pos.z + (((math.random(1, 70)/100)-0.35))}, item)
+			minetest.add_item({x = pos.x + (((math.random(1, 70)/100)-0.35)), y = pos.y+1, z = pos.z + (((math.random(1, 70)/100)-0.35))}, item)
 		end
 		invref:set_stack("craft", i, '')
 	end

--- a/api.lua
+++ b/api.lua
@@ -10,13 +10,13 @@
 
 
 -- Drop residual items from craft list
-local function drop_craft(player, pos) 
+local function drop_craft(player, pos)
 	local invref = player:get_inventory()
 	if not pos then pos = player:get_pos() end
 	local size = invref:get_size("craft")
 	for i = 1, size do
 		local item = invref:get_stack("craft", i)
-		if item ~= nil then 
+		if item ~= nil then
 			minetest.env:add_item({x = pos.x + (((math.random(1, 70)/100)-0.35)), y = pos.y+1, z = pos.z + (((math.random(1, 70)/100)-0.35))}, item)
 		end
 		invref:set_stack("craft", i, '')
@@ -24,7 +24,7 @@ local function drop_craft(player, pos)
 end
 
 -- Formspec for craft table
-local craft_table_form = 
+local craft_table_form =
 	"size[8,8.3]"..
 	default.gui_bg..
 	default.gui_bg_img..
@@ -86,7 +86,7 @@ minetest.register_allow_player_inventory_action(function(player, action, invento
 		
 		local meta = player:get_meta()
 		-- Avoid put itens at extra slots from 2x2 craft grid
-		if inventory_info.to_list == "craft" 
+		if inventory_info.to_list == "craft"
 			and meta:get_string("craft_table:craft_table_grid") == "2x2"
 		and (
 				inventory_info.to_index == 3
@@ -102,7 +102,7 @@ minetest.register_allow_player_inventory_action(function(player, action, invento
 		-- Close formspec when table is destroyed
 		if (inventory_info.to_list == "craft" or inventory_info.from_list == "craft")
 			and meta:get_string("craft_table:craft_table_grid") ~= "2x2"
-			and check_craft_table(player) == false 
+			and check_craft_table(player) == false
 		then
 			minetest.close_formspec(player:get_player_name(), "craft_table:craft_table")
 			drop_craft(player)
@@ -115,7 +115,7 @@ end)
 
 minetest.register_craft_predict(function(itemstack, player, old_craft_grid, craft_inv)
 	if player:get_meta():get_string("craft_table:craft_table_grid") ~= "2x2"
-		and check_craft_table(player) == false 
+		and check_craft_table(player) == false
 	then
 		return ''
 	end

--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,0 @@
-default
-sfinv?
-xdecor?

--- a/init.lua
+++ b/init.lua
@@ -3,7 +3,7 @@
 	Copyright (C) 2019 BrunoMine (https://github.com/BrunoMine)
 	
 	You should have received a copy of the GNU General Public License
-	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	along with this program. If not, see <https://www.gnu.org/licenses/>.
 	
   ]]
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,4 @@
 name = craft_table
 description = Add Craft Table
+depends = default
+optional_depends = sfinv, xdecor

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -5,6 +5,3 @@
 #
 # Define grade de craft 2x2 no inventario do jogador.
 craft_table_2x2_craft_grid_to_players (2x2 Craft Grid to players) bool true
-
-
-

--- a/simple_table.lua
+++ b/simple_table.lua
@@ -3,7 +3,7 @@
 	Copyright (C) 2019 BrunoMine (https://github.com/BrunoMine)
 	
 	You should have received a copy of the GNU General Public License
-	along with this program.  If not, see <https://www.gnu.org/licenses/>.
+	along with this program. If not, see <https://www.gnu.org/licenses/>.
 	
 	Simple craft table
   ]]
@@ -26,7 +26,7 @@ if minetest.registered_nodes["xdecor:workbench"] then
 	-- Remove old recipe
 	minetest.clear_craft({output = 'xdecor:workbench'})
 	-- Register new recipe
-	minetest.register_craft({ 
+	minetest.register_craft({
 		output = 'xdecor:workbench',
 		recipe = {
 			{'', 'group:wood', ''},
@@ -37,7 +37,7 @@ if minetest.registered_nodes["xdecor:workbench"] then
 end
 
 -- Craft Table recipe (classic from MC)
-minetest.register_craft({ 
+minetest.register_craft({
 	output = 'craft_table:simple',
 	recipe = {
 		{'group:wood', 'group:wood'},


### PR DESCRIPTION
Olá!

This fixes two bugs:
- Shift click in the crafting table was not possible because the inventories were not added to the listring (#2)
- The 2x2 crafting area in the inventory was broken as soon as the crafting table was used once, because the metadata string `craft_table:craft_table_grid` was never set back to "2x2"

`depends.txt` is also deprecated and Minetest warned about it.

I hope you can merge it fast, as the unusable 2x2 crafting area really breaks the mod currently.

Best regards,
Julian